### PR TITLE
disable thermanager for tone

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -153,8 +153,12 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     timekeep \
     TimeKeep \
-    thermanager \
     macaddrsetup
+
+ifneq ($(filter kanuti loire yoshino,$(PRODUCT_PLATFORM)),)
+PRODUCT_PACKAGES += \
+    thermanager
+endif
 
 # QCOM GPS
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Thermanager seems not capable of running on tone phones, and only
causes init to be triggered constantly.